### PR TITLE
Fix/check options first

### DIFF
--- a/CRUDFilters/views.py
+++ b/CRUDFilters/views.py
@@ -203,7 +203,7 @@ class CRUDFilterModelViewSet(viewsets.ModelViewSet):
 
     def process_request(self, request):
         if request.method == 'OPTIONS':
-            return HttpResponse("Coming soon", status=405)
+            return HttpResponse("Method 'OPTIONS' is not implemented.", status=405)
 
     # For the time being, this only works with token and basic auth.
     def process_view(self, request, view_func, view_args, view_kwargs):

--- a/CRUDFilters/views.py
+++ b/CRUDFilters/views.py
@@ -201,17 +201,16 @@ class CRUDFilterModelViewSet(viewsets.ModelViewSet):
                 logger.exception("Operation {} cannot be performed on requested object".format(self.request.crud_operation))
                 raise CRUDException("Cannot perform this operation on this object.", status_code=403)
 
+    def process_request(self, request):
+        if request.method == 'OPTIONS':
+            return HttpResponse("Coming soon", status=405)
+
     # For the time being, this only works with token and basic auth.
     def process_view(self, request, view_func, view_args, view_kwargs):
         """
         Perform simple authentication, then check that this user can use this role
         to perform this action (on this item).
         """
-        if request.method == 'OPTIONS':
-            # TODO: tell the user what their options are here, given their desired role.
-            # Do this before we do anything else to avoid unnecessary database hits, especially since we aren't generating it.
-            return HttpResponse("Coming soon", status=405)
-
         if not isinstance(view_func.cls(), CRUDFilterModelViewSet):
             return None
         # Create an instance of the ViewSet and get some variables from it.

--- a/CRUDFilters/views.py
+++ b/CRUDFilters/views.py
@@ -207,8 +207,12 @@ class CRUDFilterModelViewSet(viewsets.ModelViewSet):
         Perform simple authentication, then check that this user can use this role
         to perform this action (on this item).
         """
-        if not hasattr(view_func, 'cls'):
-            return None
+        method = self.request.method
+        if method == 'OPTIONS':
+            # TODO: tell the user what their options are here, given their desired role.
+            # Do this before we do anything else to avoid unnecessary database hits, especially since we aren't generating it.
+            return HttpResponse("Coming soon", status=405)
+
         if not isinstance(view_func.cls(), CRUDFilterModelViewSet):
             return None
         # Create an instance of the ViewSet and get some variables from it.
@@ -261,10 +265,6 @@ class CRUDFilterModelViewSet(viewsets.ModelViewSet):
             self.request.crud_operation = 'U'
         elif method == 'DELETE':
             self.request.crud_operation = 'D'
-        elif method == 'OPTIONS':
-            # TODO: tell the user what their options are here, given their desired role.
-            # e.g. return_options_menu_for_this_user()
-            return HttpResponse("Coming soon", status=405)
         else:
             return HttpResponse("Method not allowed", status=405)
 

--- a/CRUDFilters/views.py
+++ b/CRUDFilters/views.py
@@ -207,8 +207,7 @@ class CRUDFilterModelViewSet(viewsets.ModelViewSet):
         Perform simple authentication, then check that this user can use this role
         to perform this action (on this item).
         """
-        method = self.request.method
-        if method == 'OPTIONS':
+        if request.method == 'OPTIONS':
             # TODO: tell the user what their options are here, given their desired role.
             # Do this before we do anything else to avoid unnecessary database hits, especially since we aren't generating it.
             return HttpResponse("Coming soon", status=405)

--- a/CRUDFilters/views.py
+++ b/CRUDFilters/views.py
@@ -211,6 +211,8 @@ class CRUDFilterModelViewSet(viewsets.ModelViewSet):
         Perform simple authentication, then check that this user can use this role
         to perform this action (on this item).
         """
+        if not hasattr(view_func, 'cls'):
+            return None
         if not isinstance(view_func.cls(), CRUDFilterModelViewSet):
             return None
         # Create an instance of the ViewSet and get some variables from it.


### PR DESCRIPTION
## Purpose

It is wasteful to do the work to check for authorization, hit the DB a few times, and in general process an OPTIONS request that will always (for now) return 405. This PR adds the Django Middleware `parse_request(request)` function to our view code, and if the `request.method` is OPTIONS, we return a 405 not implemented. 
